### PR TITLE
[codex] Fix Header tests

### DIFF
--- a/src/components/__tests__/Header.test.tsx
+++ b/src/components/__tests__/Header.test.tsx
@@ -7,8 +7,8 @@ const commonProps = {
   githubUrl: 'https://example.com/repo',
   downloadUrl: 'https://example.com/archive.zip',
   items: [
-    { label: 'Home', href: '#home' },
-    { label: 'Docs', href: '#docs' },
+    { id: 'home', label: 'Home', href: '#home' },
+    { id: 'docs', label: 'Docs', href: '#docs' },
   ],
 };
 
@@ -17,7 +17,8 @@ describe('Header', () => {
     render(<Header title="Title" subtitle="Subtitle" {...commonProps} />);
     expect(screen.getByRole('heading', { name: 'Title', level: 1 })).toBeTruthy();
     expect(screen.getByText('Subtitle')).toBeTruthy();
-    expect(screen.getAllByText('Accueil').length).toBeGreaterThan(0);
+    expect(screen.getByRole('link', { name: 'Home' })).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'Docs' })).toBeTruthy();
   });
 
   it('opens and closes mobile menu', async () => {

--- a/src/components/header/Navigation.tsx
+++ b/src/components/header/Navigation.tsx
@@ -11,10 +11,10 @@ export interface NavItem {
 
 interface NavigationProps {
   className?: string;
+  items?: NavItem[];
 }
 
-export const Navigation: React.FC<NavigationProps> = ({ className = '' }) => {
-  const navigationItems: NavItem[] = [
+const defaultItems: NavItem[] = [
     {
       id: 'home',
       label: 'Accueil',
@@ -40,7 +40,10 @@ export const Navigation: React.FC<NavigationProps> = ({ className = '' }) => {
       icon: <HelpCircle size={18} />,
       href: '#',
     },
-  ];
+];
+
+export const Navigation: React.FC<NavigationProps> = ({ className = '', items = [] }) => {
+  const navigationItems = items.length ? items : defaultItems;
 
   return (
     <nav className={`hidden md:flex items-center space-x-1 ${className}`}>


### PR DESCRIPTION
## Context
- unique IDs for nav items were missing in the tests, causing React warnings
- adjust assertions to look for custom navigation labels
- update `Navigation` component to accept items prop so tests reflect injected values

## Changes
- add `id` fields in `Header.test.tsx` and assert for `Home` and `Docs`
- make `Navigation` component support custom items

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68500f38f8fc832194d6191e87e1139a