### PR TITLE
[header] centralize nav items

### DIFF
--- a/src/components/header/MobileMenu.tsx
+++ b/src/components/header/MobileMenu.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { X, Home, FileText, Settings, HelpCircle } from 'lucide-react';
+import { X } from 'lucide-react';
+import { DEFAULT_NAV_ITEMS } from './defaultNavItems';
 import type { NavItem } from './Navigation';
 import { UserActions } from './UserActions';
 
@@ -21,14 +22,7 @@ export const MobileMenu: React.FC<MobileMenuProps> = ({
   actions,
   className = '',
 }) => {
-  const menuItems = items.length
-    ? items
-    : [
-        { id: 'home', label: 'Accueil', icon: <Home size={20} />, active: true },
-        { id: 'files', label: 'Fichiers', icon: <FileText size={20} /> },
-        { id: 'settings', label: 'Param\u00e8tres', icon: <Settings size={20} /> },
-        { id: 'help', label: 'Aide', icon: <HelpCircle size={20} /> },
-      ];
+  const menuItems = items.length ? items : DEFAULT_NAV_ITEMS;
 
   return (
     <div className={`md:hidden ${className}`}>

--- a/src/components/header/Navigation.tsx
+++ b/src/components/header/Navigation.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Home, FileText, Settings, HelpCircle } from 'lucide-react';
+
+import { DEFAULT_NAV_ITEMS } from './defaultNavItems';
 
 export interface NavItem {
   id: string;
@@ -14,36 +15,9 @@ interface NavigationProps {
   items?: NavItem[];
 }
 
-const defaultItems: NavItem[] = [
-    {
-      id: 'home',
-      label: 'Accueil',
-      icon: <Home size={18} />,
-      href: '#',
-      active: true,
-    },
-    {
-      id: 'files',
-      label: 'Fichiers',
-      icon: <FileText size={18} />,
-      href: '#',
-    },
-    {
-      id: 'settings',
-      label: 'Paramètres',
-      icon: <Settings size={18} />,
-      href: '#',
-    },
-    {
-      id: 'help',
-      label: 'Aide',
-      icon: <HelpCircle size={18} />,
-      href: '#',
-    },
-];
 
 export const Navigation: React.FC<NavigationProps> = ({ className = '', items = [] }) => {
-  const navigationItems = items.length ? items : defaultItems;
+  const navigationItems = items.length ? items : DEFAULT_NAV_ITEMS;
 
   return (
     <nav className={`hidden md:flex items-center space-x-1 ${className}`}>

--- a/src/components/header/defaultNavItems.ts
+++ b/src/components/header/defaultNavItems.ts
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Home, FileText, Settings, HelpCircle } from 'lucide-react';
+import type { NavItem } from './Navigation';
+
+export const DEFAULT_NAV_ITEMS: NavItem[] = [
+  {
+    id: 'home',
+    label: 'Accueil',
+    icon: React.createElement(Home, { size: 18 }),
+    href: '#',
+    active: true,
+  },
+  {
+    id: 'files',
+    label: 'Fichiers',
+    icon: React.createElement(FileText, { size: 18 }),
+    href: '#',
+  },
+  {
+    id: 'settings',
+    label: 'Param\u00e8tres',
+    icon: React.createElement(Settings, { size: 18 }),
+    href: '#',
+  },
+  {
+    id: 'help',
+    label: 'Aide',
+    icon: React.createElement(HelpCircle, { size: 18 }),
+    href: '#',
+  },
+];


### PR DESCRIPTION
## Contexte
- partage des liens de navigation entre les composants

## Changements
- nouvelle constante `DEFAULT_NAV_ITEMS`
- utilisation de ce tableau dans `Navigation` et `MobileMenu`

## Test
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685011b7b35883218938c951d04158f1