### PR TITLE
[header] Verify default nav links

### DIFF
--- a/src/components/__tests__/Header.test.tsx
+++ b/src/components/__tests__/Header.test.tsx
@@ -31,4 +31,17 @@ describe('Header', () => {
       expect(screen.queryByText('Navigation')).toBeNull();
     });
   });
+
+  it('renders default navigation links in both desktop and mobile menus', async () => {
+    render(<Header githubUrl="https://example.com/repo" downloadUrl="https://example.com/archive.zip" />);
+
+    // Desktop navigation contains default links
+    expect(screen.getAllByRole('link', { name: 'Accueil' })).toHaveLength(1);
+
+    // Open mobile menu and expect the same default link to appear there as well
+    fireEvent.click(screen.getByLabelText('Open menu'));
+    expect(await screen.findByText('Navigation')).toBeTruthy();
+    const accueilLinks = await screen.findAllByRole('link', { name: 'Accueil' });
+    expect(accueilLinks).toHaveLength(2);
+  });
 });


### PR DESCRIPTION
## Contexte et objectif
Ajout d'un test unitaire pour vérifier que la navigation mobile et desktop utilisent les mêmes liens par défaut. Cette vérification garantit que `DEFAULT_NAV_ITEMS` est bien centralisé entre `Navigation` et `MobileMenu`.

## Étapes pour tester
1. `npm install`
2. `npm run lint`
3. `npm test`

## Impact éventuel
Aucun impact sur les autres agents.

------
https://chatgpt.com/codex/tasks/task_e_68501468c2e48321b2b84ab742e26ed2