### PR TITLE
[docs] Clarify navigation items prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ Glissez-déposez vos fichiers dans l'interface ou cliquez sur **Choisir des fich
 
 Vous pouvez ajuster les limites de traitement dans un fichier `.env`. Le guide [docs/guides/configuration.md](docs/guides/configuration.md) liste les variables disponibles.
 
+## 🧭 Navigation personnalisée
+
+Les composants `Header` et `Navigation` exposent la prop `items?: NavItem[]`.
+Passez-lui une liste `{ id, label, icon, href }` pour définir vos liens.
+Si aucun tableau n'est fourni, la constante `DEFAULT_NAV_ITEMS` sert de menu par défaut.
+
 ## 🧠 Architecture
 
 ```mermaid


### PR DESCRIPTION
## Contexte et objectif
Ajout d'une courte section dans le README pour expliquer la prop `items?: NavItem[]` des composants `Header` et `Navigation`. La documentation précise que `DEFAULT_NAV_ITEMS` est utilisé si aucune liste n'est fournie.

## Étapes pour tester
1. `npm install`
2. `npm run lint`
3. `npm test`

## Impact éventuel sur les autres agents
Aucun impact sur les agents existants.

------
https://chatgpt.com/codex/tasks/task_e_6850175143148321a98d8eac88221a08