### PR TITLE
[work] User actions links via props

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -6,9 +6,17 @@ import { MobileMenu } from './MobileMenu';
 
 interface HeaderProps {
   className?: string;
+  githubUrl?: string;
+  downloadUrl?: string;
 }
 
-export const Header: React.FC<HeaderProps> = ({ className = '' }) => {
+export const Header: React.FC<HeaderProps> = ({
+  className = '',
+  githubUrl = 'https://github.com/Fr3doo/Postman_Runner_File_Processor',
+  downloadUrl = '#',
+}) => {
+  const actions = { githubUrl, downloadUrl };
+
   return (
     <header className={`
       sticky top-0 z-30 bg-white/95 backdrop-blur-sm border-b border-gray-200
@@ -24,8 +32,8 @@ export const Header: React.FC<HeaderProps> = ({ className = '' }) => {
 
           {/* User Actions */}
           <div className="flex items-center space-x-4">
-            <UserActions />
-            <MobileMenu />
+            <UserActions {...actions} />
+            <MobileMenu actions={actions} />
           </div>
         </div>
       </div>

--- a/src/components/header/UserActions.tsx
+++ b/src/components/header/UserActions.tsx
@@ -2,15 +2,23 @@ import React from 'react';
 import { Github, Download, ExternalLink } from 'lucide-react';
 
 interface UserActionsProps {
+  /** GitHub repository URL */
+  githubUrl: string;
+  /** URL to download the application */
+  downloadUrl: string;
   className?: string;
 }
 
-export const UserActions: React.FC<UserActionsProps> = ({ className = '' }) => {
+export const UserActions: React.FC<UserActionsProps> = ({
+  githubUrl,
+  downloadUrl,
+  className = '',
+}) => {
   return (
     <div className={`flex items-center space-x-3 ${className}`}>
       {/* GitHub Link */}
       <a
-        href="https://github.com/Fr3doo/Postman_Runner_File_Processor"
+        href={githubUrl}
         target="_blank"
         rel="noopener noreferrer"
         className="
@@ -25,7 +33,9 @@ export const UserActions: React.FC<UserActionsProps> = ({ className = '' }) => {
       </a>
 
       {/* Download Button */}
-      <button
+      <a
+        href={downloadUrl}
+        download
         className="
           flex items-center space-x-2 px-4 py-2 bg-gradient-to-r from-blue-600 to-purple-600
           text-white rounded-lg hover:from-blue-700 hover:to-purple-700
@@ -36,7 +46,7 @@ export const UserActions: React.FC<UserActionsProps> = ({ className = '' }) => {
       >
         <Download size={18} />
         <span className="hidden sm:inline">Télécharger</span>
-      </button>
+      </a>
     </div>
   );
 };


### PR DESCRIPTION
## Contexte et objectif
- rendre configurables les liens GitHub et téléchargement dans `UserActions`
- propager ces URLs dans le Header interne

## Étapes pour tester
1. `npm install`
2. `npm run lint`
3. `npm test`

Aucun impact sur les autres agents.

------
https://chatgpt.com/codex/tasks/task_e_68501c7120108321ab59b5767f7fbd70