### PR TITLE
[work] Update header tests for new mobile menu

### DIFF
--- a/src/components/__tests__/Header.test.tsx
+++ b/src/components/__tests__/Header.test.tsx
@@ -13,23 +13,55 @@ const commonProps = {
 };
 
 describe('Header', () => {
-  it('renders title, subtitle and navigation items', () => {
+  it('renders title, subtitle and custom navigation items in both menus', async () => {
     render(<Header title="Title" subtitle="Subtitle" {...commonProps} />);
+
+    // Title and subtitle
     expect(screen.getByRole('heading', { name: 'Title', level: 1 })).toBeTruthy();
     expect(screen.getByText('Subtitle')).toBeTruthy();
-    expect(screen.getByRole('link', { name: 'Home' })).toBeTruthy();
-    expect(screen.getByRole('link', { name: 'Docs' })).toBeTruthy();
+
+    // Custom navigation in desktop menu
+    expect(screen.getAllByRole('link', { name: 'Home' })).toHaveLength(1);
+    expect(screen.getAllByRole('link', { name: 'Docs' })).toHaveLength(1);
+
+    // Custom navigation should appear in mobile menu as well
+    fireEvent.click(screen.getByLabelText('Open menu'));
+    await screen.findByRole('dialog');
+    expect(screen.getAllByRole('link', { name: 'Home' })).toHaveLength(2);
+    expect(screen.getAllByRole('link', { name: 'Docs' })).toHaveLength(2);
   });
 
   it('opens and closes mobile menu', async () => {
     render(<Header {...commonProps} />);
-    const btn = screen.getByLabelText('Open menu');
-    fireEvent.click(btn);
-    expect(await screen.findByText('Navigation')).toBeTruthy();
-    fireEvent.click(screen.getByLabelText('Close menu'));
+
+    fireEvent.click(screen.getByLabelText('Open menu'));
+    const dialog = await screen.findByRole('dialog');
+    expect(dialog).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Close menu' })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close menu' }));
     await waitFor(() => {
-      expect(screen.queryByText('Navigation')).toBeNull();
+      expect(screen.queryByRole('dialog')).toBeNull();
     });
+  });
+
+  it('uses provided URLs for user actions', async () => {
+    render(<Header {...commonProps} />);
+
+    // Desktop actions
+    const [githubLink, downloadLink] = [
+      screen.getByRole('link', { name: 'GitHub' }),
+      screen.getByRole('link', { name: 'Télécharger' }),
+    ];
+    expect(githubLink.getAttribute('href')).toBe(commonProps.githubUrl);
+    expect(downloadLink.getAttribute('href')).toBe(commonProps.downloadUrl);
+
+    // Mobile actions should use the same URLs
+    fireEvent.click(screen.getByLabelText('Open menu'));
+    const githubLinks = await screen.findAllByRole('link', { name: 'GitHub' });
+    const downloadLinks = await screen.findAllByRole('link', { name: 'Télécharger' });
+    expect(githubLinks[1].getAttribute('href')).toBe(commonProps.githubUrl);
+    expect(downloadLinks[1].getAttribute('href')).toBe(commonProps.downloadUrl);
   });
 
   it('renders default navigation links in both desktop and mobile menus', async () => {


### PR DESCRIPTION
## Context and goal
- align header tests with new MobileMenu markup
- assert provided URLs are used in user actions
- ensure dynamic nav items appear in both menus

## Testing steps
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685029083a788321873a8e94646ee157