### PR TITLE
[work] Add FileHistoryService tests

### DIFF
--- a/src/services/__tests__/FileHistoryService.test.ts
+++ b/src/services/__tests__/FileHistoryService.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { fileHistoryService } from '../FileHistoryService';
+import type { ProcessedFile } from '../../types';
+
+const createFile = (id: string): ProcessedFile => ({
+  id,
+  filename: `${id}.txt`,
+  status: 'success',
+});
+
+describe('fileHistoryService', () => {
+  beforeEach(() => {
+    fileHistoryService.clearHistory();
+    window.localStorage.clear();
+  });
+
+  it('adds files to the beginning of history', () => {
+    const a = createFile('a');
+    const b = createFile('b');
+    fileHistoryService.addFile(a);
+    fileHistoryService.addFile(b);
+    const history = fileHistoryService.getHistory();
+    expect(history[0].id).toBe('b');
+    expect(history[1].id).toBe('a');
+  });
+
+  it('getHistory returns a copy', () => {
+    const f = createFile('x');
+    fileHistoryService.addFile(f);
+    const hist = fileHistoryService.getHistory();
+    hist.push(createFile('y'));
+    expect(fileHistoryService.getHistory().length).toBe(1);
+  });
+
+  it('removes files by id', () => {
+    const a = createFile('a');
+    const b = createFile('b');
+    fileHistoryService.addFile(a);
+    fileHistoryService.addFile(b);
+    fileHistoryService.removeFile('a');
+    const ids = fileHistoryService.getHistory().map((f) => f.id);
+    expect(ids).not.toContain('a');
+  });
+
+  it('clears history', () => {
+    fileHistoryService.addFile(createFile('a'));
+    fileHistoryService.clearHistory();
+    expect(fileHistoryService.getHistory().length).toBe(0);
+  });
+
+  it('saves and loads history from localStorage', () => {
+    const f = createFile('p');
+    fileHistoryService.addFile(f);
+    fileHistoryService.save();
+    fileHistoryService.clearHistory();
+    expect(fileHistoryService.getHistory().length).toBe(0);
+    fileHistoryService.load();
+    expect(fileHistoryService.getHistory()[0].id).toBe('p');
+  });
+
+  it('handles localStorage errors gracefully', () => {
+    const setSpy = vi
+      .spyOn(window.localStorage, 'setItem')
+      .mockImplementation(() => {
+        throw new Error('fail');
+      });
+    const getSpy = vi
+      .spyOn(window.localStorage, 'getItem')
+      .mockImplementation(() => {
+        throw new Error('fail');
+      });
+
+    expect(() => fileHistoryService.save()).not.toThrow();
+    expect(() => fileHistoryService.load()).not.toThrow();
+
+    setSpy.mockRestore();
+    getSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Contexte et objectif
Ajout d'un fichier de tests unitaires pour `FileHistoryService` dans `src/services/__tests__`. Les tests couvrent l'ajout, la suppression, la réinitialisation et la persistance de l'historique, ainsi que la gestion des erreurs `localStorage`.

## Étapes pour tester
1. `npm run lint`
2. `npm test`

Aucun impact sur les autres agents.

------
https://chatgpt.com/codex/tasks/task_e_68503d82429c8321ad7d98fbf22b262f