### PR TITLE
[services] record processed files

### DIFF
--- a/src/services/FileProcessor.ts
+++ b/src/services/FileProcessor.ts
@@ -13,6 +13,7 @@ import { ErrorHandler } from './ErrorHandler';
 import { RateLimitError, ValidationError } from '../utils/errors';
 import { ValidationResult } from '../utils/securityValidator';
 import { ProcessFileCommand } from './ProcessFileCommand';
+import { fileHistoryService } from './FileHistoryService';
 
 export class FileProcessor {
   constructor(
@@ -98,6 +99,7 @@ export class FileProcessor {
         setProcessedFiles,
         this.errorHandler,
         this.loggingService,
+        fileHistoryService,
       );
       return () =>
         command.execute().then(() => new Promise((r) => setTimeout(r, 300)));


### PR DESCRIPTION
## Contexte et objectif
- inject optional `FileHistoryService` into `ProcessFileCommand`
- save each processed file (success or failure) to history
- pass the history service when commands are created
- update unit tests

## Étapes pour tester
1. `npm run lint`
2. `npm test`

Aucun impact sur les autres agents.

------
https://chatgpt.com/codex/tasks/task_e_68503eaf7ec08321be3a8152382178d9