### PR TITLE
[history] Add FileHistory context

### DIFF
--- a/src/components/FileHistoryContext.tsx
+++ b/src/components/FileHistoryContext.tsx
@@ -1,0 +1,58 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import {
+  fileHistoryService,
+  type IFileHistoryService,
+} from '../services/FileHistoryService';
+import type { ProcessedFile } from '../types';
+
+/* eslint-disable react-refresh/only-export-components */
+
+interface FileHistoryContextValue {
+  history: ProcessedFile[];
+  removeFile: (id: string) => void;
+  clearHistory: () => void;
+}
+
+const FileHistoryContext = createContext<FileHistoryContextValue | undefined>(
+  undefined,
+);
+
+export const FileHistoryProvider: React.FC<{
+  children: React.ReactNode;
+  service?: IFileHistoryService;
+}> = ({ children, service = fileHistoryService }) => {
+  const [history, setHistory] = useState<ProcessedFile[]>([]);
+
+  useEffect(() => {
+    service.load();
+    setHistory(service.getHistory());
+  }, [service]);
+
+  const handleRemove = (id: string) => {
+    service.removeFile(id);
+    setHistory(service.getHistory());
+    service.save();
+  };
+
+  const handleClear = () => {
+    service.clearHistory();
+    setHistory(service.getHistory());
+    service.save();
+  };
+
+  return (
+    <FileHistoryContext.Provider
+      value={{ history, removeFile: handleRemove, clearHistory: handleClear }}
+    >
+      {children}
+    </FileHistoryContext.Provider>
+  );
+};
+
+export const useFileHistory = (): FileHistoryContextValue => {
+  const context = useContext(FileHistoryContext);
+  if (!context) {
+    throw new Error('useFileHistory must be used within a FileHistoryProvider');
+  }
+  return context;
+};

--- a/src/components/__tests__/FileHistoryContext.test.tsx
+++ b/src/components/__tests__/FileHistoryContext.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { FileHistoryProvider, useFileHistory } from '../FileHistoryContext';
+import type { IFileHistoryService } from '../../services/FileHistoryService';
+import type { ProcessedFile } from '../../types';
+
+const createFile = (id: string): ProcessedFile => ({
+  id,
+  filename: `${id}.txt`,
+  status: 'success',
+});
+
+const createMockService = (initial: ProcessedFile[]): IFileHistoryService & {
+  getLoadCount(): number;
+} => {
+  let history = [...initial];
+  const load = vi.fn(() => {
+    history = [...initial];
+  });
+  const removeFile = vi.fn((id: string) => {
+    history = history.filter((f) => f.id !== id);
+  });
+  const clearHistory = vi.fn(() => {
+    history = [];
+  });
+  const save = vi.fn();
+  return {
+    addFile: vi.fn(),
+    getHistory: () => [...history],
+    removeFile,
+    clearHistory,
+    load,
+    save,
+    getLoadCount: () => load.mock.calls.length,
+  };
+};
+
+describe('FileHistoryProvider', () => {
+  it('loads history on mount and updates on remove/clear', () => {
+    const files = [createFile('a'), createFile('b')];
+    const service = createMockService(files);
+    const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+      <FileHistoryProvider service={service}>{children}</FileHistoryProvider>
+    );
+
+    const { result } = renderHook(() => useFileHistory(), { wrapper });
+
+    expect(service.getLoadCount()).toBe(1);
+    expect(result.current.history).toEqual(files);
+
+    act(() => {
+      result.current.removeFile('a');
+    });
+    expect(service.removeFile).toHaveBeenCalledWith('a');
+    expect(result.current.history.some((f) => f.id === 'a')).toBe(false);
+
+    act(() => {
+      result.current.clearHistory();
+    });
+    expect(service.clearHistory).toHaveBeenCalled();
+    expect(result.current.history.length).toBe(0);
+    expect(service.save).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws when used outside FileHistoryProvider', () => {
+    const fn = () => renderHook(() => useFileHistory());
+    expect(fn).toThrow('useFileHistory must be used within a FileHistoryProvider');
+  });
+});


### PR DESCRIPTION
## Contexte et objectif
- Fournir un contexte React pour l'historique des fichiers traités.
- Permet de charger, supprimer et réinitialiser l'historique via `FileHistoryService`.
- Ajouter des tests unitaires pour ce nouveau contexte.

## Étapes pour tester
1. `npm run lint`
2. `npm test`

## Impact éventuel
- Aucun impact sur les autres agents.

------
https://chatgpt.com/codex/tasks/task_e_68504d9c3404832180fc0d5ee83cc90d