### PR TITLE
[webapp] Ajout page historique

### DIFF
--- a/src/components/pages/FileHistoryPage.tsx
+++ b/src/components/pages/FileHistoryPage.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { FileHistoryProvider, useFileHistory } from '../FileHistoryContext';
+import { FileHistoryGrid } from '../FileHistoryGrid';
+import { ProcessingStatsComponent } from '../ProcessingStats';
+import type { ProcessingStats } from '../../types';
+
+const HistoryContent: React.FC = () => {
+  const { history, clearHistory } = useFileHistory();
+
+  const stats: ProcessingStats = React.useMemo(
+    () => ({
+      total: history.length,
+      processed: history.length,
+      successful: history.filter((f) => f.status === 'success').length,
+      failed: history.filter((f) => f.status === 'error').length,
+    }),
+    [history],
+  );
+
+  return (
+    <main className="container mx-auto px-4 py-8">
+      <ProcessingStatsComponent stats={stats} onClearResults={clearHistory} />
+      <FileHistoryGrid />
+    </main>
+  );
+};
+
+export const FileHistoryPage: React.FC = () => (
+  <FileHistoryProvider>
+    <HistoryContent />
+  </FileHistoryProvider>
+);
+
+export default FileHistoryPage;

--- a/src/components/pages/index.ts
+++ b/src/components/pages/index.ts
@@ -1,0 +1,1 @@
+export { FileHistoryPage } from './FileHistoryPage';


### PR DESCRIPTION
## Contexte et objectif
- ajout d'une page affichant l'historique des fichiers traités
- export pour intégration future dans `App.tsx`

## Étapes pour tester
1. `npm run lint`
2. `npm test`

## Impact
- aucune régression attendue, nouvelle page autonome

------
https://chatgpt.com/codex/tasks/task_e_6850551044fc8321af0b3b6a0e51dd26