### PR TITLE
[docs] Ajouter historique fichiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Consultez [docs/guides/contributing.md](docs/guides/contributing.md) pour les é
 - [Schémas d'architecture](docs/reference/architecture.md)
 - [Changelog](docs/releases/changelog.md)
 - [Guide de configuration](docs/guides/configuration.md)
+- [Historique des fichiers](docs/guides/file-history.md)
 - [Guide des agents](AGENTS.md)
 
 ## 📦 Publication sur npm

--- a/docs/guides/file-history.md
+++ b/docs/guides/file-history.md
@@ -1,0 +1,22 @@
+# Historique des fichiers traités
+
+Ce guide explique comment l'application conserve en local les fichiers déjà traités et comment les récupérer ou les supprimer.
+
+## 1. Stockage local
+
+`FileHistoryService` maintient une liste de `ProcessedFile` en mémoire. Cette liste est sauvegardée dans `localStorage` sous la clé `fileHistory` quand vous quittez l'application puis restaurée au chargement suivant.
+
+Aucune donnée n'est envoyée sur un serveur. Vous pouvez inspecter ou vider ce stockage via les outils du navigateur si besoin.
+
+## 2. Retélécharger un fichier
+
+Depuis la page **Historique des fichiers**, chaque carte affiche un bouton **Télécharger à nouveau**. Il génère à partir des données enregistrées un fichier JSON identique à celui obtenu lors du traitement initial.
+
+## 3. Supprimer l'historique
+
+Deux options existent :
+
+- Cliquez sur **Supprimer** sur une carte pour retirer uniquement ce fichier.
+- Utilisez **Effacer l'historique** en haut de la page pour tout réinitialiser. Cette action vide aussi `localStorage`.
+
+Vous pouvez ensuite importer de nouveaux fichiers et redémarrer un historique propre.

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,7 @@ La documentation est organisée dans les dossiers suivants :
 - [`guides/usage-example.md`](guides/usage-example.md) – Exemple de workflow pour téléverser des fichiers et obtenir les résultats.
 - [`guides/configuration.md`](guides/configuration.md) – Comment ajuster les paramètres de sécurité et d’exécution.
 - [`guides/logging-and-errors.md`](guides/logging-and-errors.md) – Journaliser les actions et afficher des messages d’erreur sûrs.
+- [`guides/file-history.md`](guides/file-history.md) – Gérer l’historique et re-télécharger les fichiers.
 - [`guides/cli-tests.md`](guides/cli-tests.md) – Exécuter les tests du convertisseur en ligne de commande.
 - [`guides/advanced-testing.md`](guides/advanced-testing.md) – Mocker la configuration et simuler le DOM dans les tests.
   D’autres guides avancés sont les bienvenus.


### PR DESCRIPTION
## Contexte et objectif
- documenter la conservation locale des fichiers traités
- référencer ce guide dans l'index et le README

## Étapes pour tester
1. `npm install`
2. `npm run lint`
3. `npm test`

## Impact
Documentation uniquement

------
https://chatgpt.com/codex/tasks/task_e_6850693f1f0c83219a2d15100326af0b