### PR TITLE
[ProcessFileCommand] Save file history after add

### DIFF
--- a/src/services/ProcessFileCommand.ts
+++ b/src/services/ProcessFileCommand.ts
@@ -48,6 +48,7 @@ export class ProcessFileCommand {
       );
       if (finalFile) {
         this.fileHistoryService.addFile(finalFile);
+        this.fileHistoryService.save();
       }
       this.loggingService.logInfo(`Processed ${this.file.name} successfully`);
     } catch (error) {
@@ -64,6 +65,7 @@ export class ProcessFileCommand {
       );
       if (finalFile) {
         this.fileHistoryService.addFile(finalFile);
+        this.fileHistoryService.save();
       }
       this.loggingService.logError(
         `Failed processing ${this.file.name}: ${message}`,

--- a/src/services/__tests__/ProcessFileCommand.test.ts
+++ b/src/services/__tests__/ProcessFileCommand.test.ts
@@ -56,6 +56,7 @@ describe('ProcessFileCommand with history', () => {
     expect(historyService.addFile).toHaveBeenCalledWith(
       expect.objectContaining({ status: 'success', filename: 'a.txt' }),
     );
+    expect(historyService.save).toHaveBeenCalled();
     expect(processed[0]?.status).toBe('success');
   });
 
@@ -65,6 +66,7 @@ describe('ProcessFileCommand with history', () => {
     expect(historyService.addFile).toHaveBeenCalledWith(
       expect.objectContaining({ status: 'error', error: expect.stringContaining('fail') }),
     );
+    expect(historyService.save).toHaveBeenCalled();
     expect(processed[0]?.status).toBe('error');
   });
 });


### PR DESCRIPTION
## Contexte et objectif
Ajout de la sauvegarde de l'historique immédiatement après l'ajout d'un fichier via `ProcessFileCommand`, afin d'assurer la persistance de l'historique.

## Étapes pour tester
1. `npm run lint`
2. `npm test`

Aucun impact sur les autres agents.

------
https://chatgpt.com/codex/tasks/task_e_68507fd031988321a26cbeb0283ecaf2