### PR TITLE
[work] Add malformed data test for FileHistoryService

### DIFF
--- a/src/utils/__tests__/fileHistoryService.test.ts
+++ b/src/utils/__tests__/fileHistoryService.test.ts
@@ -74,4 +74,14 @@ describe('fileHistoryService', () => {
     setSpy.mockRestore();
     getSpy.mockRestore();
   });
+
+  it('resets history when localStorage returns malformed data', () => {
+    fileHistoryService.addFile(createFile('a'));
+    const spy = vi
+      .spyOn(Object.getPrototypeOf(window.localStorage), 'getItem')
+      .mockReturnValue('not-json');
+    expect(() => fileHistoryService.load()).not.toThrow();
+    expect(fileHistoryService.getHistory()).toEqual([]);
+    spy.mockRestore();
+  });
 });


### PR DESCRIPTION
## Contexte et objectif
- ajouter un cas de test vérifiant `fileHistoryService.load()` quand `localStorage` retourne une chaîne invalide
- s'assurer que l'historique est vidé sans erreur

## Étapes pour tester
1. `npm run lint`
2. `npm test`

Aucun impact sur les autres agents.

------
https://chatgpt.com/codex/tasks/task_e_685084b3399883219120ffd558f4e346