### PR TITLE
[core] FileHistory auto-save

### DIFF
--- a/src/components/FileHistoryContext.tsx
+++ b/src/components/FileHistoryContext.tsx
@@ -31,13 +31,11 @@ export const FileHistoryProvider: React.FC<{
   const handleRemove = (id: string) => {
     service.removeFile(id);
     setHistory(service.getHistory());
-    service.save();
   };
 
   const handleClear = () => {
     service.clearHistory();
     setHistory(service.getHistory());
-    service.save();
   };
 
   return (

--- a/src/components/__tests__/FileHistoryContext.test.tsx
+++ b/src/components/__tests__/FileHistoryContext.test.tsx
@@ -60,7 +60,7 @@ describe('FileHistoryProvider', () => {
     });
     expect(service.clearHistory).toHaveBeenCalled();
     expect(result.current.history.length).toBe(0);
-    expect(service.save).toHaveBeenCalledTimes(2);
+    expect(service.save).not.toHaveBeenCalled();
   });
 
   it('throws when used outside FileHistoryProvider', () => {

--- a/src/services/FileHistoryService.ts
+++ b/src/services/FileHistoryService.ts
@@ -19,6 +19,7 @@ class FileHistoryService implements IFileHistoryService {
 
   addFile(file: ProcessedFile): void {
     this.history.unshift(file);
+    this.save();
   }
 
   getHistory(): ProcessedFile[] {
@@ -27,10 +28,12 @@ class FileHistoryService implements IFileHistoryService {
 
   removeFile(id: string): void {
     this.history = this.history.filter((f) => f.id !== id);
+    this.save();
   }
 
   clearHistory(): void {
     this.history = [];
+    this.save();
   }
 
   load(): void {

--- a/src/services/ProcessFileCommand.ts
+++ b/src/services/ProcessFileCommand.ts
@@ -48,7 +48,6 @@ export class ProcessFileCommand {
       );
       if (finalFile) {
         this.fileHistoryService.addFile(finalFile);
-        this.fileHistoryService.save();
       }
       this.loggingService.logInfo(`Processed ${this.file.name} successfully`);
     } catch (error) {
@@ -65,7 +64,6 @@ export class ProcessFileCommand {
       );
       if (finalFile) {
         this.fileHistoryService.addFile(finalFile);
-        this.fileHistoryService.save();
       }
       this.loggingService.logError(
         `Failed processing ${this.file.name}: ${message}`,

--- a/src/services/__tests__/FileHistoryService.test.ts
+++ b/src/services/__tests__/FileHistoryService.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { fileHistoryService } from '../FileHistoryService';
+import { fileHistoryService, FileHistoryService } from '../FileHistoryService';
 import type { ProcessedFile } from '../../types';
 
 const createFile = (id: string): ProcessedFile => ({
@@ -51,11 +51,9 @@ describe('fileHistoryService', () => {
   it('saves and loads history from localStorage', () => {
     const f = createFile('p');
     fileHistoryService.addFile(f);
-    fileHistoryService.save();
-    fileHistoryService.clearHistory();
-    expect(fileHistoryService.getHistory().length).toBe(0);
-    fileHistoryService.load();
-    expect(fileHistoryService.getHistory()[0].id).toBe('p');
+    const newService = new FileHistoryService();
+    newService.load();
+    expect(newService.getHistory()[0].id).toBe('p');
   });
 
   it('handles localStorage errors gracefully', () => {

--- a/src/services/__tests__/ProcessFileCommand.test.ts
+++ b/src/services/__tests__/ProcessFileCommand.test.ts
@@ -56,7 +56,6 @@ describe('ProcessFileCommand with history', () => {
     expect(historyService.addFile).toHaveBeenCalledWith(
       expect.objectContaining({ status: 'success', filename: 'a.txt' }),
     );
-    expect(historyService.save).toHaveBeenCalled();
     expect(processed[0]?.status).toBe('success');
   });
 
@@ -66,7 +65,6 @@ describe('ProcessFileCommand with history', () => {
     expect(historyService.addFile).toHaveBeenCalledWith(
       expect.objectContaining({ status: 'error', error: expect.stringContaining('fail') }),
     );
-    expect(historyService.save).toHaveBeenCalled();
     expect(processed[0]?.status).toBe('error');
   });
 });

--- a/src/utils/__tests__/fileHistoryService.test.ts
+++ b/src/utils/__tests__/fileHistoryService.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { fileHistoryService } from '../../services/FileHistoryService';
+import { fileHistoryService, FileHistoryService } from '../../services/FileHistoryService';
 import type { ProcessedFile } from '../../types';
 
 const createFile = (id: string): ProcessedFile => ({
@@ -51,11 +51,9 @@ describe('fileHistoryService', () => {
   it('saves and loads history from localStorage', () => {
     const f = createFile('p');
     fileHistoryService.addFile(f);
-    fileHistoryService.save();
-    fileHistoryService.clearHistory();
-    expect(fileHistoryService.getHistory().length).toBe(0);
-    fileHistoryService.load();
-    expect(fileHistoryService.getHistory()[0].id).toBe('p');
+    const newService = new FileHistoryService();
+    newService.load();
+    expect(newService.getHistory()[0].id).toBe('p');
   });
 
   it('handles localStorage errors gracefully', () => {


### PR DESCRIPTION
## Contexte et objectif
- Les opérations `addFile`, `removeFile` et `clearHistory` sauvegardent désormais automatiquement l'historique.
- Mise à jour des composants et tests pour retirer les appels `save()` redondants.

## Étapes pour tester
1. `npm run lint`
2. `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685091fe18f483219b686f48d90b62e2