### PR TITLE
[work] Add FileHistoryService localStorage merge test

### DIFF
--- a/src/services/__tests__/FileHistoryService.test.ts
+++ b/src/services/__tests__/FileHistoryService.test.ts
@@ -56,6 +56,20 @@ describe('fileHistoryService', () => {
     expect(newService.getHistory()[0].id).toBe('p');
   });
 
+  it('preserves existing localStorage items when instantiated', () => {
+    const oldFile = createFile('old');
+    window.localStorage.setItem('fileHistory', JSON.stringify([oldFile]));
+
+    const newService = new FileHistoryService();
+    const newFile = createFile('new');
+    newService.addFile(newFile);
+
+    const ids = newService.getHistory().map((f) => f.id);
+    expect(ids).toContain('old');
+    expect(ids).toContain('new');
+    expect(ids[0]).toBe('new');
+  });
+
   it('handles localStorage errors gracefully', () => {
     const setSpy = vi
       .spyOn(window.localStorage, 'setItem')


### PR DESCRIPTION
## Contexte et objectif
Ajout d'un test pour vérifier que `FileHistoryService` conserve les éléments déjà présents dans `localStorage` lors de son initialisation et qu'ils restent après l'ajout d'un nouveau fichier.

## Étapes pour tester
1. `npm run lint`
2. `npm test`

## Impact
Aucun impact sur les autres agents.

------
https://chatgpt.com/codex/tasks/task_e_6850f6f0a5608321a35d3154b1379dec