### PR TITLE
[file-history] Add subscription mechanism

### DIFF
--- a/src/components/FileHistoryContext.tsx
+++ b/src/components/FileHistoryContext.tsx
@@ -25,17 +25,16 @@ export const FileHistoryProvider: React.FC<{
 
   useEffect(() => {
     service.load();
-    setHistory(service.getHistory());
+    const unsubscribe = service.subscribe(setHistory);
+    return () => unsubscribe();
   }, [service]);
 
   const handleRemove = (id: string) => {
     service.removeFile(id);
-    setHistory(service.getHistory());
   };
 
   const handleClear = () => {
     service.clearHistory();
-    setHistory(service.getHistory());
   };
 
   return (


### PR DESCRIPTION
## Contexte et objectif
- ajout d'une API `subscribe` dans `FileHistoryService`
- `FileHistoryProvider` s'abonne au service et réagit aux notifications
- nouveaux tests pour vérifier la mise à jour lors de l'ajout de fichier

## Étapes pour tester
```bash
npm run lint
npm test
```

## Impact
Aucun impact attendu sur les autres agents.

------
https://chatgpt.com/codex/tasks/task_e_6850f99090c88321b963e04558d5c5a1