### PR TITLE
[work] check history save not called

### DIFF
--- a/src/services/__tests__/ProcessFileCommand.test.ts
+++ b/src/services/__tests__/ProcessFileCommand.test.ts
@@ -56,6 +56,7 @@ describe('ProcessFileCommand with history', () => {
     expect(historyService.addFile).toHaveBeenCalledWith(
       expect.objectContaining({ status: 'success', filename: 'a.txt' }),
     );
+    expect(historyService.save).not.toHaveBeenCalled();
     expect(processed[0]?.status).toBe('success');
   });
 
@@ -65,6 +66,7 @@ describe('ProcessFileCommand with history', () => {
     expect(historyService.addFile).toHaveBeenCalledWith(
       expect.objectContaining({ status: 'error', error: expect.stringContaining('fail') }),
     );
+    expect(historyService.save).not.toHaveBeenCalled();
     expect(processed[0]?.status).toBe('error');
   });
 });


### PR DESCRIPTION
## Contexte et objectif
- Mise à jour du test de `ProcessFileCommand` pour vérifier qu'aucun appel direct à `save()` n'est effectué lorsque l'historique est mis à jour.

## Étapes pour tester
1. `npm run lint`
2. `npm test`

## Impact éventuel
- Aucun autre agent impacté.

------
https://chatgpt.com/codex/tasks/task_e_685101f5f52c8321a7c8fee10232c284