### PR TITLE
[docs] Mention auto history save and empty state

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Consultez [docs/guides/contributing.md](docs/guides/contributing.md) pour les é
 - [Changelog](docs/releases/changelog.md)
 - [Guide de configuration](docs/guides/configuration.md)
 - [Historique des fichiers](docs/guides/file-history.md)
+- [Chargement automatique et état vide](docs/guides/file-history.md#chargement-automatique-et-etat-vide)
 - [Guide des agents](AGENTS.md)
 
 ## 📦 Publication sur npm

--- a/docs/guides/file-history.md
+++ b/docs/guides/file-history.md
@@ -7,6 +7,7 @@ Ce guide décrit pas à pas comment l’application stocke les fichiers traités
 1. Après chaque traitement, `FileHistoryService` ajoute un objet `ProcessedFile` à une liste en mémoire.
 2. Avant de fermer ou de recharger la page, cette liste est sauvegardée dans `localStorage` sous la clé `fileHistory`.
 3. Au prochain démarrage, la liste est restaurée à partir de cette clé.
+4. Le service charge ainsi l'historique automatiquement et sauvegarde chaque modification sans action supplémentaire.
 
 Aucune donnée n’est envoyée sur un serveur. Vous pouvez inspecter ou vider ce stockage via les outils du navigateur.
 
@@ -21,3 +22,7 @@ Aucune donnée n’est envoyée sur un serveur. Vous pouvez inspecter ou vider c
 1. Pour retirer un fichier isolé, cliquez sur **Supprimer** sur sa carte.
 2. Pour tout effacer, utilisez **Effacer l’historique** en haut de la page. L’entrée `fileHistory` est alors supprimée de `localStorage`.
 3. Vous pouvez ensuite importer de nouveaux fichiers et recommencer avec un historique vide.
+
+## 4. Chargement automatique et état vide
+
+L'historique se charge dès l'ouverture de l'application et se sauvegarde après chaque action. Lorsque la liste est vide, une phrase *Aucun fichier dans l'historique.* s'affiche pour indiquer l'état actuel.


### PR DESCRIPTION
## Contexte
Add clarification about the automatic loading of the file history and its empty-state message.

## Étapes pour tester
1. `npm run lint`
2. `npm test`

## Impact
Documentation only.

------
https://chatgpt.com/codex/tasks/task_e_685104005704832192cd278a164df92f