### PR TITLE
[FileProcessor] Consolidate warning loops

### DIFF
--- a/src/services/FileProcessor.ts
+++ b/src/services/FileProcessor.ts
@@ -69,10 +69,10 @@ export class FileProcessor {
     }
 
     if (validation.warnings.length > 0) {
-      validation.warnings.forEach((w) => this.notifyService.addWarning(w));
-      validation.warnings.forEach((w) =>
-        this.loggingService.logInfo(`Warning: ${w}`),
-      );
+      for (const w of validation.warnings) {
+        this.notifyService.addWarning(w);
+        this.loggingService.logInfo(`Warning: ${w}`);
+      }
     }
 
     setIsProcessing(true);


### PR DESCRIPTION
## Contexte
Un doublon de boucle `forEach` gérait les avertissements de validation dans `FileProcessor`. Cette PR simplifie ce bloc.

## Étapes pour tester
1. `npm install`
2. `npm run lint`
3. `npm test`

## Impact
Aucun impact sur les autres agents.

------
https://chatgpt.com/codex/tasks/task_e_685112608e4c83219239cfa7077464c5