### PR TITLE
docs add detailed project structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,15 +97,19 @@ graph TD
 ## 📁 Structure du projet
 
 ```
-├─ src/            # Code source React/TypeScript
-│  ├─ components/  # Composants UI
-│  ├─ services/    # Services et logique métier
-│  ├─ utils/       # Fonctions de parsing et validation
-│  └─ config/      # Constantes de configuration
-├─ docs/           # Documentation détaillée
-├─ .github/        # Workflows CI
-└─ README.md
+├─ src/             # Code source TypeScript
+│  ├─ cli/          # Script de conversion en ligne de commande
+│  ├─ components/   # Composants et contextes React
+│  ├─ hooks/        # Hooks personnalisés
+│  ├─ services/     # Couche métier
+│  ├─ utils/        # Fonctions de parsing et tests
+│  └─ config/       # Valeurs de configuration
+├─ docs/            # Documentation
+├─ .github/         # Workflows CI
+└─ index.html      # Entrée de l'application
 ```
+
+La vue complète de l'arborescence se trouve dans [docs/reference/project-structure.md](docs/reference/project-structure.md).
 
 ## 🧪 Tests
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,6 +37,7 @@ La documentation est organisée dans les dossiers suivants :
 
 - [`reference/api-reference.md`](reference/api-reference.md) – Documentation des fonctions utilitaires et modules.
 - [`reference/architecture.md`](reference/architecture.md) – Détails sur la structure des dossiers et l’architecture.
+- [`reference/project-structure.md`](reference/project-structure.md) – Aperçu complet de l'organisation du projet.
 - [`reference/tests-overview.md`](reference/tests-overview.md) – Aperçu des tests et instructions d’exécution.
 - [`reference/security-config.md`](reference/security-config.md) – Explication des constantes de sécurité.
 - [`reference/events.md`](reference/events.md) – Cycle des logs et des messages.

--- a/docs/reference/project-structure.md
+++ b/docs/reference/project-structure.md
@@ -1,0 +1,29 @@
+# Structure détaillée du projet
+
+Cette page décrit en profondeur l’organisation des dossiers et fichiers principaux.
+
+```
+root/
+├─ src/                  # Code source principal
+│  ├─ cli/               # Script CLI et tests associés
+│  ├─ components/        # Composants React et contextes
+│  ├─ config/            # Valeurs de configuration
+│  ├─ hooks/             # Hooks personnalisés
+│  ├─ i18n/              # Gestion de la traduction
+│  ├─ services/          # Logique métier et accès aux utilitaires
+│  │  └─ __tests__/      # Tests unitaires des services
+│  ├─ types/             # Types TypeScript partagés
+│  └─ utils/             # Fonctions d’aide et leurs tests
+├─ docs/                 # Documentation structurée
+│  ├─ guides/            # Guides pratiques
+│  ├─ overview/          # Aperçus généraux
+│  ├─ reference/         # Références techniques
+│  └─ releases/          # Notes de versions
+├─ .github/              # Workflows CI et configuration GitHub
+├─ index.html            # Point d’entrée HTML pour l’application
+├─ package.json          # Dépendances et scripts npm
+├─ vite.config.ts        # Configuration Vite
+└─ tsconfig.json         # Configuration TypeScript
+```
+
+Chaque dossier suit la philosophie « un rôle clair ». Les tests unitaires se trouvent généralement à côté du code qu’ils vérifient.


### PR DESCRIPTION
## Contexte et objectif

Ajout d'une vue plus complète de l'arborescence du projet. Le README contient désormais un aperçu élargi et renvoie vers un nouveau fichier `project-structure.md` dans la documentation.

## Étapes pour tester

1. `npm run lint`
2. `npm test`

## Impact éventuel

Aucun impact sur les autres agents.

------
https://chatgpt.com/codex/tasks/task_e_685117254cdc8321af6139d52ec88379