### PR TITLE
cli Ajoute index des conversions

### DIFF
--- a/docs/guides/cli-tests.md
+++ b/docs/guides/cli-tests.md
@@ -27,3 +27,9 @@ Quand le module est importé par Vitest, `import.meta.main` vaut `false`.
 Le CLI démarre donc grâce à cet appel direct.
 
 Consultez la section [Exclusions de couverture](../reference/tests-overview.md#exclusions-de-couverture) pour connaître les fichiers ignorés lors des tests.
+
+## 3. Index des fichiers générés
+
+Chaque conversion ajoute une entrée dans `convert-index.json`.
+Ce fichier placé dans le dossier de sortie liste le chemin du JSON,
+l'horodatage de la création et le nombre d'enregistrements convertis.

--- a/src/cli/__tests__/convert.test.ts
+++ b/src/cli/__tests__/convert.test.ts
@@ -55,6 +55,14 @@ describe('run', () => {
       numero_dossier: '1',
       date_depot: '2024-01-01',
     });
+
+    const index = JSON.parse(await fs.readFile('convert-index.json', 'utf8'));
+    expect(index.length).toBe(1);
+    expect(index[0]).toMatchObject({
+      path: join(tempDir, 'input.json'),
+      recordCount: 1,
+    });
+    expect(typeof index[0].timestamp).toBe('string');
   });
 
   it('creates multiple JSON files when multiple summaries found', async () => {
@@ -90,6 +98,17 @@ describe('run', () => {
     const files = await fs.readdir('.');
     expect(files).toContain('multi-1.json');
     expect(files).toContain('multi-2.json');
+
+    const index = JSON.parse(await fs.readFile('convert-index.json', 'utf8'));
+    expect(index.length).toBe(2);
+    expect(index[0]).toMatchObject({
+      path: join(tempDir, 'multi-1.json'),
+      recordCount: 1,
+    });
+    expect(index[1]).toMatchObject({
+      path: join(tempDir, 'multi-2.json'),
+      recordCount: 1,
+    });
   });
 
   it('creates JSON files for each provided input', async () => {
@@ -119,6 +138,17 @@ describe('run', () => {
     };
     expect(JSON.parse(out1)).toEqual(expected);
     expect(JSON.parse(out2)).toEqual(expected);
+
+    const index = JSON.parse(await fs.readFile('convert-index.json', 'utf8'));
+    expect(index.length).toBe(2);
+    expect(index[0]).toMatchObject({
+      path: join(tempDir, 'first.json'),
+      recordCount: 1,
+    });
+    expect(index[1]).toMatchObject({
+      path: join(tempDir, 'second.json'),
+      recordCount: 1,
+    });
   });
 
   it('logs error when readFile fails', async () => {

--- a/src/components/pages/LocalFilesPage.tsx
+++ b/src/components/pages/LocalFilesPage.tsx
@@ -40,7 +40,6 @@ export const LocalFilesPage: React.FC<LocalFilesPageProps> = ({ service = localF
       // Consider showing a user notification here
     }
   };
-  };
 
   return (
     <main className="container mx-auto px-4 py-8">

--- a/src/services/LocalFileService.ts
+++ b/src/services/LocalFileService.ts
@@ -21,14 +21,22 @@ export class LocalFileService implements ILocalFileService {
   }
 
   async deleteFile(filename: string): Promise<void> {
+    if (!filename || filename.includes('..') || filename.includes('/') || filename.includes('\\')) {
+      throw new Error('Invalid filename provided');
+    }
     try {
       await fs.unlink(join(this.directory, filename));
     } catch (err) {
       console.error(`Failed to delete file ${filename}`, err);
+      throw err;
     }
   }
 
   async downloadFile(filename: string): Promise<string> {
+    if (!filename || filename.includes('..') || filename.includes('/') || filename.includes('\\')) {
+      throw new Error('Invalid filename provided');
+    }
+
     const filePath = join(this.directory, filename);
     const data = await fs.readFile(filePath, 'utf8');
     if (

--- a/src/services/__tests__/LocalFileService.test.ts
+++ b/src/services/__tests__/LocalFileService.test.ts
@@ -62,7 +62,13 @@ describe('LocalFileService', () => {
     expect(createObjectURLSpy).toHaveBeenCalled();
     expect(revokeObjectURLSpy).toHaveBeenCalled();
     expect(appendChildSpy).toHaveBeenCalledWith(anchor);
-  // Add these security test cases:
+    expect(removeChildSpy).toHaveBeenCalledWith(anchor);
+
+    createElementSpy.mockRestore();
+    createObjectURLSpy.mockRestore();
+    clickSpy.mockRestore();
+  });
+
   it('rejects invalid filenames in deleteFile', async () => {
     await expect(service.deleteFile('../invalid')).rejects.toThrow('Invalid filename');
     await expect(service.deleteFile('')).rejects.toThrow('Invalid filename');
@@ -72,10 +78,6 @@ describe('LocalFileService', () => {
   it('rejects invalid filenames in downloadFile', async () => {
     await expect(service.downloadFile('../invalid')).rejects.toThrow('Invalid filename');
     await expect(service.downloadFile('path\\traversal')).rejects.toThrow('Invalid filename');
-  });
-    createElementSpy.mockRestore();
-    createObjectURLSpy.mockRestore();
-    clickSpy.mockRestore();
   });
 });
 


### PR DESCRIPTION
## Contexte et objectif
- journaliser chaque fichier JSON généré par le CLI
- documenter l'index dans la doc CLI
- tester la mise à jour de cet index

## Étapes pour tester
1. `npm install`
2. `npm run lint`
3. `npm test`

## Impact éventuel
- `LocalFileService` effectue de nouveau la validation des noms de fichiers


------
https://chatgpt.com/codex/tasks/task_e_68513c6b4f688321b93c3c4f7d9612b8