### PR TITLE
[FileHistoryService] Cap history length

### DIFF
--- a/docs/reference/security-config.md
+++ b/docs/reference/security-config.md
@@ -26,3 +26,4 @@ La constante `SECURITY_CONFIG` dans `src/config/security.ts` définit les règle
 
 - `RATE_LIMIT_WINDOW` – fenêtre temporelle en millisecondes utilisée pour limiter les téléversements (60 000 ms).
 - `RATE_LIMIT_MAX_FILES` – nombre de fichiers autorisés par fenêtre (100).
+- `FILE_HISTORY_MAX_ENTRIES` – nombre maximal d’éléments conservés dans l’historique (50).

--- a/src/config/security.ts
+++ b/src/config/security.ts
@@ -27,4 +27,7 @@ export const SECURITY_CONFIG = {
   // Rate limiting (files per minute)
   RATE_LIMIT_WINDOW: 60 * 1000, // 1 minute
   RATE_LIMIT_MAX_FILES: 100,
+
+  // File history
+  FILE_HISTORY_MAX_ENTRIES: 50,
 } as const;

--- a/src/services/ConfigService.ts
+++ b/src/services/ConfigService.ts
@@ -9,6 +9,7 @@ export interface SecurityConfig {
   DANGEROUS_PATTERNS: RegExp[];
   RATE_LIMIT_WINDOW: number;
   RATE_LIMIT_MAX_FILES: number;
+  FILE_HISTORY_MAX_ENTRIES: number;
 }
 
 import { SECURITY_CONFIG } from '../config/security';
@@ -84,6 +85,10 @@ class ConfigService {
       RATE_LIMIT_MAX_FILES: this.getNumber(
         'RATE_LIMIT_MAX_FILES',
         SECURITY_CONFIG.RATE_LIMIT_MAX_FILES,
+      ),
+      FILE_HISTORY_MAX_ENTRIES: this.getNumber(
+        'FILE_HISTORY_MAX_ENTRIES',
+        SECURITY_CONFIG.FILE_HISTORY_MAX_ENTRIES,
       ),
     };
   }

--- a/src/services/FileHistoryService.ts
+++ b/src/services/FileHistoryService.ts
@@ -11,18 +11,22 @@ export interface IFileHistoryService {
 }
 
 import type { ProcessedFile } from '../types';
+import { configService } from './ConfigService';
 
 class FileHistoryService implements IFileHistoryService {
   private history: ProcessedFile[] = [];
   private readonly storageKey = 'fileHistory';
   private listeners: HistoryListener[] = [];
-
-  constructor() {
+  constructor(
+    private readonly maxEntries = configService.security.FILE_HISTORY_MAX_ENTRIES,
+  ) {
     this.load();
   }
-
   addFile(file: ProcessedFile): void {
     this.history.unshift(file);
+    if (this.history.length > this.maxEntries) {
+      this.history = this.history.slice(0, this.maxEntries);
+    }
     this.save();
     this.notify();
   }
@@ -58,6 +62,9 @@ class FileHistoryService implements IFileHistoryService {
     } catch {
       this.history = [];
     }
+    if (this.history.length > this.maxEntries) {
+      this.history = this.history.slice(0, this.maxEntries);
+    }
     this.notify();
   }
 
@@ -84,5 +91,7 @@ class FileHistoryService implements IFileHistoryService {
   }
 }
 
-export const fileHistoryService: IFileHistoryService = new FileHistoryService();
+export const fileHistoryService: IFileHistoryService = new FileHistoryService(
+  configService.security.FILE_HISTORY_MAX_ENTRIES,
+);
 export { FileHistoryService };

--- a/src/services/__tests__/FileHistoryService.test.ts
+++ b/src/services/__tests__/FileHistoryService.test.ts
@@ -36,6 +36,15 @@ describe('fileHistoryService', () => {
     expect(fileHistoryService.getHistory().length).toBe(1);
   });
 
+  it('trims history to the maximum size', () => {
+    const svc = new FileHistoryService(2);
+    svc.addFile(createFile('a'));
+    svc.addFile(createFile('b'));
+    svc.addFile(createFile('c'));
+    const ids = svc.getHistory().map((f) => f.id);
+    expect(ids).toEqual(['c', 'b']);
+  });
+
   it('removes files by id', () => {
     const a = createFile('a');
     const b = createFile('b');

--- a/src/services/__tests__/configService.test.ts
+++ b/src/services/__tests__/configService.test.ts
@@ -23,6 +23,7 @@ describe('ConfigService env overrides', () => {
     process.env.VITE_ALLOWED_MIME_TYPES = 'text/plain,text/log';
     process.env.VITE_RATE_LIMIT_WINDOW = '60';
     process.env.VITE_RATE_LIMIT_MAX_FILES = '5';
+    process.env.VITE_FILE_HISTORY_MAX_ENTRIES = '2';
 
     const svc = new ConfigService(process.env);
     expect(svc.concurrencyLimit).toBe(10);
@@ -38,6 +39,7 @@ describe('ConfigService env overrides', () => {
       DANGEROUS_PATTERNS: SECURITY_CONFIG.DANGEROUS_PATTERNS,
       RATE_LIMIT_WINDOW: 60,
       RATE_LIMIT_MAX_FILES: 5,
+      FILE_HISTORY_MAX_ENTRIES: 2,
     });
   });
 });

--- a/src/utils/__tests__/fileHistoryService.test.ts
+++ b/src/utils/__tests__/fileHistoryService.test.ts
@@ -32,6 +32,15 @@ describe('fileHistoryService', () => {
     expect(fileHistoryService.getHistory().length).toBe(1);
   });
 
+  it('trims history to the maximum size', () => {
+    const svc = new FileHistoryService(2);
+    svc.addFile(createFile('a'));
+    svc.addFile(createFile('b'));
+    svc.addFile(createFile('c'));
+    const ids = svc.getHistory().map((f) => f.id);
+    expect(ids).toEqual(['c', 'b']);
+  });
+
   it('removes files by id', () => {
     const a = createFile('a');
     const b = createFile('b');


### PR DESCRIPTION
## Contexte et objectif
- ajouter un nombre maximum d'entrées pour l'historique des fichiers
- documenter la nouvelle constante de sécurité
- tester le retrait des éléments dépassant la limite

## Étapes pour tester
1. `npm install`
2. `npm run lint`
3. `npm test`

## Impact
- `FileHistoryService` limite désormais la taille de l'historique

------
https://chatgpt.com/codex/tasks/task_e_6851633b3f1c83218c5b0fa3db9a9c6c