### PR TITLE
[localfile] Node-only file service handling

### DIFF
--- a/docs/guides/contributing.md
+++ b/docs/guides/contributing.md
@@ -102,6 +102,7 @@ Ce projet utilise :
    ```
 
 2. Ouvre l’onglet **Locaux** pour voir la liste des fichiers `.json` présents dans le dossier courant.
+   Cette page utilise l'API `fs` de Node.js et ne fonctionne pas dans un build navigateur standard.
 3. Les tests unitaires du service se trouvent dans `src/services/__tests__/LocalFileService.test.ts` :
 
    ```bash

--- a/docs/overview/limitations.md
+++ b/docs/overview/limitations.md
@@ -1,6 +1,7 @@
 # Limitations connues
 
 Cette application fonctionne uniquement dans le navigateur et ne possède pas de composant serveur. Les fichiers chargés ne sont jamais envoyés sur un backend.
+La page **Locaux** nécessite cependant l'environnement Node.js pour accéder au système de fichiers local.
 
 ## Limites de débit
 

--- a/src/components/__tests__/LocalFilesPage.test.tsx
+++ b/src/components/__tests__/LocalFilesPage.test.tsx
@@ -42,4 +42,20 @@ describe('LocalFilesPage', () => {
       expect(screen.getByText(/Aucun fichier/)).toBeTruthy();
     });
   });
+
+  it('displays an error when service fails', async () => {
+    const service = {
+      listJSONFiles: vi.fn(async () => {
+        throw new Error('unsupported');
+      }),
+      deleteFile: vi.fn(),
+      downloadFile: vi.fn(),
+    } as LocalFileServiceClass;
+
+    render(<LocalFilesPage service={service} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('error').textContent).toContain('unsupported');
+    });
+  });
 });

--- a/src/components/pages/LocalFilesPage.tsx
+++ b/src/components/pages/LocalFilesPage.tsx
@@ -9,13 +9,16 @@ interface LocalFilesPageProps {
 
 export const LocalFilesPage: React.FC<LocalFilesPageProps> = ({ service = localFileService }) => {
   const [files, setFiles] = React.useState<string[]>([]);
+  const [error, setError] = React.useState<string | null>(null);
 
   const loadFiles = React.useCallback(async () => {
     try {
       const list = await service.listJSONFiles();
       setFiles(list);
+      setError(null);
     } catch (err) {
       console.error(err);
+      setError((err as Error).message);
     }
   }, [service]);
 
@@ -44,7 +47,11 @@ export const LocalFilesPage: React.FC<LocalFilesPageProps> = ({ service = localF
   return (
     <main className="container mx-auto px-4 py-8">
       <h1 className="text-3xl font-bold text-gray-900 mb-6">Fichiers locaux</h1>
-      {files.length === 0 ? (
+      {error ? (
+        <div className="text-center py-10 text-red-500" data-testid="error">
+          {error}
+        </div>
+      ) : files.length === 0 ? (
         <div className="text-center py-10 text-gray-500">Aucun fichier dans le dossier.</div>
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">

--- a/src/services/LocalFileService.ts
+++ b/src/services/LocalFileService.ts
@@ -1,5 +1,6 @@
-import { promises as fs } from 'fs';
-import { join } from 'path';
+
+export const isNode = (): boolean =>
+  typeof process !== 'undefined' && !!process.versions?.node;
 
 export interface ILocalFileService {
   listJSONFiles(): Promise<string[]>;
@@ -11,7 +12,13 @@ export class LocalFileService implements ILocalFileService {
   constructor(private directory: string = process.cwd()) {}
 
   async listJSONFiles(): Promise<string[]> {
+    if (!isNode()) {
+      throw new Error(
+        "La lecture des fichiers locaux n'est pas disponible dans ce navigateur."
+      );
+    }
     try {
+      const { promises: fs } = await import('fs');
       const files = await fs.readdir(this.directory);
       return files.filter((f) => f.toLowerCase().endsWith('.json'));
     } catch (err) {
@@ -24,7 +31,14 @@ export class LocalFileService implements ILocalFileService {
     if (!filename || filename.includes('..') || filename.includes('/') || filename.includes('\\')) {
       throw new Error('Invalid filename provided');
     }
+    if (!isNode()) {
+      throw new Error(
+        "La suppression de fichiers locaux n'est pas disponible dans ce navigateur."
+      );
+    }
     try {
+      const { promises: fs } = await import('fs');
+      const { join } = await import('path');
       await fs.unlink(join(this.directory, filename));
     } catch (err) {
       console.error(`Failed to delete file ${filename}`, err);
@@ -36,7 +50,14 @@ export class LocalFileService implements ILocalFileService {
     if (!filename || filename.includes('..') || filename.includes('/') || filename.includes('\\')) {
       throw new Error('Invalid filename provided');
     }
+    if (!isNode()) {
+      throw new Error(
+        "Le t\xE9l\xE9chargement de fichiers locaux n'est pas disponible dans ce navigateur."
+      );
+    }
 
+    const { promises: fs } = await import('fs');
+    const { join } = await import('path');
     const filePath = join(this.directory, filename);
     const data = await fs.readFile(filePath, 'utf8');
     if (


### PR DESCRIPTION
## Contexte
Ajout d'une détection d'environnement Node pour le service de fichiers locaux. Les imports `fs` et `path` sont désormais dynamiques afin d'éviter les erreurs en environnement navigateur. La page **Locaux** affiche un message d'erreur clair si l'accès aux fichiers n'est pas disponible.

## Changements
- Dynamisation des imports dans `LocalFileService` avec une fonction `isNode`.
- Gestion d'erreur et affichage dans `LocalFilesPage`.
- Mise à jour de la documentation sur la contrainte Node.
- Ajout d'un test de rendu en erreur de la page.

## Test
- `npm run lint`
- `npm test`

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6851b1438c48832185607b146f2b07b2