### PR TITLE
[work] Corrige avertissement React

### DIFF
--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -2,16 +2,20 @@ import React from 'react';
 
 export type CardProps = React.HTMLAttributes<HTMLDivElement>;
 
-export const Card: React.FC<CardProps> = ({
-  className = '',
-  children,
-  ...props
-}) => {
-  return (
-    <div className={`bg-white rounded-xl shadow p-6 ${className}`} {...props}>
-      {children}
-    </div>
-  );
-};
+export const Card = React.forwardRef<HTMLDivElement, CardProps>(
+  ({ className = '', children, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={`bg-white rounded-xl shadow p-6 ${className}`}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  },
+);
+
+Card.displayName = 'Card';
 
 export default Card;


### PR DESCRIPTION
## Contexte
L'exécution des tests affichait un avertissement indiquant que le composant `Card` ne pouvait pas recevoir de `ref`. Le composant `FileUpload` passait pourtant une `ref` au composant `Card`, entraînant ce message.

## Objectif
Adapter `Card` pour qu'il supporte correctement les références React en utilisant `React.forwardRef`.

## Test
- `npm run lint`
- `npm test`

## Agent
- Aucun impact sur les autres agents

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6851d3acbcc88321ad9a7b681d94bf83