### PR TITLE
[LocalFileService] Ajustement du constructeur

### DIFF
--- a/src/services/LocalFileService.ts
+++ b/src/services/LocalFileService.ts
@@ -8,7 +8,16 @@ export interface ILocalFileService {
 }
 
 export class LocalFileService implements ILocalFileService {
-  constructor(private directory: string = process.cwd()) {}
+  private directory: string;
+  constructor(directory?: string) {
+    if (directory) {
+      this.directory = directory;
+    } else if (typeof process !== 'undefined' && process.cwd) {
+      this.directory = process.cwd();
+    } else {
+      this.directory = '';
+    }
+  }
 
   private isNode(): boolean {
     return (


### PR DESCRIPTION
## Contexte
Le service `LocalFileService` utilisait `process.cwd()` comme valeur par défaut dans son constructeur. Cela posait problème dans les environnements où `process` n'est pas défini.

## Objectif
Initialiser le répertoire de travail de manière conditionnelle afin d'éviter toute erreur d'exécution côté navigateur ou dans des environnements restreints.

## Test
- `npm run lint`
- `npm test`

## Agent
Impact limité aux appels du service `LocalFileService`.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6851eba61d5c832196d011767b474e27