### PR TITLE
[LocalFileService] Accès navigateur au système de fichiers

### DIFF
--- a/docs/guides/usage-example.md
+++ b/docs/guides/usage-example.md
@@ -79,3 +79,10 @@ setLanguage('en');
 ```
 
 Toutes les étiquettes et messages s'afficheront alors en anglais.
+
+## 8. Utilisation dans le navigateur
+
+La page **Fichiers locaux** peut accéder directement à un dossier sur votre ordinateur.
+Lors de la première ouverture, l'application demande l'autorisation via une fenêtre de sélection.
+Après validation, le dossier choisi est réutilisé pour lister, télécharger ou supprimer les fichiers JSON.
+Si vous videz les permissions ou changez d'onglet, la demande sera affichée de nouveau.

--- a/src/components/pages/LocalFilesPage.tsx
+++ b/src/components/pages/LocalFilesPage.tsx
@@ -20,8 +20,22 @@ export const LocalFilesPage: React.FC<LocalFilesPageProps> = ({ service = localF
   }, [service]);
 
   React.useEffect(() => {
-    loadFiles();
-  }, [loadFiles]);
+    const init = async () => {
+      if (typeof window !== 'undefined' && 'showDirectoryPicker' in window) {
+        if ('hasDirectoryHandle' in service && !service.hasDirectoryHandle()) {
+          try {
+            // @ts-expect-error method existence checked above
+            await service.requestDirectoryAccess();
+          } catch (err) {
+            console.error(err);
+            return;
+          }
+        }
+      }
+      await loadFiles();
+    };
+    void init();
+  }, [loadFiles, service]);
   const handleDownload = async (filename: string) => {
     try {
       await service.downloadFile(filename);

--- a/src/services/__tests__/LocalFileService.browser.test.ts
+++ b/src/services/__tests__/LocalFileService.browser.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { LocalFileService } from '../LocalFileService';
+
+type FileRecord = Record<string, string>;
+
+class MockFileHandle {
+  name: string;
+  private content: string;
+  kind = 'file' as const;
+  constructor(name: string, content: string) {
+    this.name = name;
+    this.content = content;
+  }
+  async getFile() {
+    return {
+      text: async () => this.content,
+    } as File;
+  }
+}
+
+class MockDirectoryHandle {
+  private files: Map<string, MockFileHandle>;
+  constructor(entries: FileRecord) {
+    this.files = new Map(
+      Object.entries(entries).map(([name, c]) => [name, new MockFileHandle(name, c)]),
+    );
+  }
+  async *values() {
+    for (const f of this.files.values()) {
+      yield f;
+    }
+  }
+  async getFileHandle(name: string) {
+    const f = this.files.get(name);
+    if (!f) throw new Error('not found');
+    return f;
+  }
+  async removeEntry(name: string) {
+    this.files.delete(name);
+  }
+}
+
+let service: LocalFileService;
+let directory: MockDirectoryHandle;
+
+beforeEach(() => {
+  service = new LocalFileService();
+  (service as unknown as { isNode: () => boolean }).isNode = () => false;
+  directory = new MockDirectoryHandle({ 'd.json': '{"a":1}' });
+  (globalThis as unknown as { showDirectoryPicker: () => Promise<MockDirectoryHandle> }).showDirectoryPicker = vi.fn(async () => directory);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('LocalFileService browser API', () => {
+  it('requests access and lists files', async () => {
+    const handle = await service.requestDirectoryAccess();
+    expect(handle).toBe(directory);
+    const list = await service.listJSONFiles();
+    expect(list).toEqual(['d.json']);
+    expect(globalThis.showDirectoryPicker).toHaveBeenCalled();
+  });
+
+  it('downloads and deletes files', async () => {
+    await service.requestDirectoryAccess();
+
+    const createElementSpy = vi.spyOn(document, 'createElement');
+    const appendChildSpy = vi.spyOn(document.body, 'appendChild');
+    const removeChildSpy = vi.spyOn(document.body, 'removeChild');
+    Object.defineProperty(URL, 'createObjectURL', { writable: true, value: () => 'blob:url' });
+    const createSpy = vi.spyOn(URL, 'createObjectURL');
+    Object.defineProperty(URL, 'revokeObjectURL', { writable: true, value: vi.fn() });
+    const revokeSpy = vi.spyOn(URL, 'revokeObjectURL');
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+
+    const data = await service.downloadFile('d.json');
+    expect(data).toBe('{"a":1}');
+    expect(createElementSpy).toHaveBeenCalledWith('a');
+    expect(createSpy).toHaveBeenCalled();
+    expect(revokeSpy).toHaveBeenCalled();
+    expect(appendChildSpy).toHaveBeenCalled();
+    expect(removeChildSpy).toHaveBeenCalled();
+
+    await service.deleteFile('d.json');
+    const filesAfter = await service.listJSONFiles();
+    expect(filesAfter).toEqual([]);
+
+    createElementSpy.mockRestore();
+    createSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Contexte et objectif
Ajout du support complet de l'API File System Access côté navigateur. Le service `LocalFileService` détecte désormais l'environnement et peut demander l'accès à un dossier local pour lister, télécharger et supprimer les fichiers JSON. La page `LocalFilesPage` déclenche la demande de permission lors du premier affichage si nécessaire. Des tests unitaires couvrent cette nouvelle branche navigateur et la documentation explique le comportement.

## Test
- `npm run lint`
- `npm test`

## Agent
- Impact limité au service `LocalFileService` et à la page `LocalFilesPage`.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6851f7afdbe483218abaf488b81da074