### PR TITLE
[docs] Ajout du guide local-files

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Consultez [docs/guides/contributing.md](docs/guides/contributing.md) pour les é
 - [Changelog](docs/releases/changelog.md)
 - [Guide de configuration](docs/guides/configuration.md)
 - [Historique des fichiers](docs/guides/file-history.md)
+- [Fichiers locaux](docs/guides/local-files.md)
 - [Chargement automatique et état vide](docs/guides/file-history.md#chargement-automatique-et-etat-vide)
 - [Guide des agents](AGENTS.md)
 

--- a/docs/guides/local-files.md
+++ b/docs/guides/local-files.md
@@ -1,0 +1,18 @@
+# Fichiers locaux
+
+La page **Fichiers locaux** liste les fichiers JSON disponibles dans le dossier que vous autorisez.
+Elle permet de les télécharger ou de les supprimer directement depuis l’application.
+
+## 1. Pré-requis
+
+Cette fonctionnalité s’appuie sur l’API **File System Access** du navigateur.
+Seuls les navigateurs compatibles peuvent accéder à un dossier local.
+
+## 2. Autoriser l’accès à un dossier
+
+1. Ouvrez l’onglet **Locaux** dans la barre de navigation.
+2. Cliquez sur **Sélectionner un dossier** si aucun répertoire n’est encore associé.
+3. Choisissez le dossier contenant vos fichiers JSON et validez.
+4. Le navigateur peut demander une confirmation d’accès : acceptez pour continuer.
+
+Une fois l’autorisation accordée, la liste des fichiers s’affiche avec les boutons **Télécharger** et **Supprimer**.

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,7 @@ La documentation est organisée dans les dossiers suivants :
 - [`guides/configuration.md`](guides/configuration.md) – Comment ajuster les paramètres de sécurité et d’exécution.
 - [`guides/logging-and-errors.md`](guides/logging-and-errors.md) – Journaliser les actions et afficher des messages d’erreur sûrs.
 - [`guides/file-history.md`](guides/file-history.md) – Gérer l’historique, suivre les métriques et re-télécharger les fichiers.
+- [`guides/local-files.md`](guides/local-files.md) – Accéder à un dossier via l’API File System Access.
 - [`guides/cli-tests.md`](guides/cli-tests.md) – Exécuter les tests du convertisseur en ligne de commande.
 - [`guides/advanced-testing.md`](guides/advanced-testing.md) – Mocker la configuration et simuler le DOM dans les tests.
   D’autres guides avancés sont les bienvenus.


### PR DESCRIPTION
## Contexte et objectif
Ajout d'une nouvelle page de documentation expliquant l'usage de la vue **Fichiers locaux** et le prérequis d'accès au système de fichiers. Ce guide est référencé depuis l'index de la documentation et le README.

## Test
- `npm run lint`
- `npm test`

## Agent
Aucun impact sur les autres agents.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6851fabd0d3883218a112f75bcb3ad71